### PR TITLE
Fixed issue with define_attribute_methods to work with Rails 3

### DIFF
--- a/lib/active_bugzilla/bug/flags_management.rb
+++ b/lib/active_bugzilla/bug/flags_management.rb
@@ -64,7 +64,7 @@ module ActiveBugzilla::Bug::FlagsManagement
   end
 
   included do
-    define_attribute_methods :flags
+    define_attribute_methods [:flags]
 
     alias_method :changed_without_flags?, :changed?
     alias_method :changed?, :changed_with_flags?


### PR DESCRIPTION
With this fix, active_bugzilla can be loaded in both Rails 3 & 4
