### PR TITLE
Fixed issue where non-existent included attributes are refetched upon ac...

### DIFF
--- a/lib/active_bugzilla/bug.rb
+++ b/lib/active_bugzilla/bug.rb
@@ -75,6 +75,9 @@ module ActiveBugzilla
       options[:include_fields] << :id unless options[:include_fields].include?(:id)
 
       search(options).collect do |bug_hash|
+        options[:include_fields].each do |field|
+          bug_hash[field] = nil unless bug_hash.key?(field)
+        end
         Bug.new(bug_hash)
       end
     end


### PR DESCRIPTION
...cess.

Where a find has include_fields define some attributes, where
those attributes are not defined in the obtained bugzilla
issue. An access to those fields will result in additional
xmlrpc searches.  Fix is to make sure those are defined as nil
in the returned bug hashes
