### PR TITLE
Fixed Issue with Flags being returned in Raw mode

### DIFF
--- a/lib/active_bugzilla/bug.rb
+++ b/lib/active_bugzilla/bug.rb
@@ -79,7 +79,7 @@ module ActiveBugzilla
       search(options).collect do |bug_hash|
         fields_to_include.each do |field|
           bug_hash[field] = nil unless bug_hash.key?(field)
-          bug_hash[field] = FlagsManagement.flags_from_raw_flags_data(bug_hash[field]) if field == :flags
+          bug_hash[field] = flags_from_raw_flags_data(bug_hash[field]) if field == :flags
         end
         Bug.new(bug_hash)
       end

--- a/lib/active_bugzilla/bug/flags_management.rb
+++ b/lib/active_bugzilla/bug/flags_management.rb
@@ -4,6 +4,16 @@ require 'dirty_hashy'
 module ActiveBugzilla::Bug::FlagsManagement
   extend ActiveSupport::Concern
 
+  module ClassMethods
+    def flags_from_raw_flags_data(raw_flags_data)
+      return {} if raw_flags_data.nil?
+      flag_objects = ActiveBugzilla::Flag.instantiate_from_raw_data(raw_flags_data)
+      flag_objects.each_with_object({}) do |flag, hash|
+        hash[flag.name] = flag.status
+      end
+    end
+  end
+
   def flag_objects
     @flag_objects ||= ActiveBugzilla::Flag.instantiate_from_raw_data(raw_flags, @id)
   end
@@ -20,14 +30,6 @@ module ActiveBugzilla::Bug::FlagsManagement
       end
       flags_hash.clean_up!
       flags_hash
-    end
-  end
-
-  def self.flags_from_raw_flags_data(raw_flags_data)
-    return {} if raw_flags_data.nil?
-    flag_objects = ActiveBugzilla::Flag.instantiate_from_raw_data(raw_flags_data)
-    flag_objects.each_with_object({}) do |flag, hash|
-      hash[flag.name] = flag.status
     end
   end
 


### PR DESCRIPTION
When flags are requested via the :include_fields, they were
returned as raw instead of the hash.  Also, fixed issue where
duplicate_id was not seen in :include_fields as the lower
level service was updating that option with the BugZilla
equivalent of dupe_of.
