### PR TITLE
Simplify keywords API

### DIFF
--- a/lib/active_bugzilla/bug.rb
+++ b/lib/active_bugzilla/bug.rb
@@ -40,7 +40,7 @@ module ActiveBugzilla
       # Default subcommand to keywords_set to simplify API
       # and support user supplied Hash.
       return HashWithIndifferentAccess.new(value) if value.is_a?(Hash)
-      HashWithIndifferentAccess.new({"keywords_set" => value}) # default to keywords_set
+      HashWithIndifferentAccess.new("keywords_set" => value)
     end
 
     def update_attributes(attributes)


### PR DESCRIPTION
This pull request adds support to simplify the handling of keywords while
also allowing for the use of all of the keyword sub-commands supported by the
xmlrpc API. Although the underlying XMLRPC support for keywords sub-commands 
is murky.

By default the user does not have to be concerned that the XMPRPC interface for
modifying keywords requires a sub-command. By default the user can provide an
array of keywords, to match what is returned from a query for keywords.

e.g.:

require "active_bugzilla"
service = ActiveBugzilla::Service.new("https://partner-bugzilla.redhat.com", "cfme-bot@redhat.com",  "*********")
ActiveBugzilla::Base.service = service
bug = ActiveBugzilla::Bug.find(:id => [965147]).last
puts "#{bug.keywords}"
=> ["UseCase", "UserExperience", "ZStream"]

bug.keywords.delete("UseCase")
bug.keywords << "Upstream"
bug.update_attributes(:keywords => bug.keywords)

Although the underlying XMLRPC support for keyword sub-commands is murky,
access to it is provided.
e.g.:
bug.update_attributes(:keywords => {"keywords_add" => ["UseCase"]})
