### PR TITLE
Make port and SSL optional

### DIFF
--- a/lib/active_bugzilla/service.rb
+++ b/lib/active_bugzilla/service.rb
@@ -59,10 +59,10 @@ module ActiveBugzilla
     end
 
     def https?
-      URI.parse(self.bugzilla_uri).scheme == 'https'
+      URI.parse(bugzilla_uri).scheme == 'https'
     end
 
-    def initialize(bugzilla_uri, username, password, options={})
+    def initialize(bugzilla_uri, username, password, options = {})
       raise ArgumentError, "username and password must be set" if username.nil? || password.nil?
 
       self.bugzilla_uri = bugzilla_uri
@@ -189,7 +189,7 @@ module ActiveBugzilla
 
     DEFAULT_OPTIONS = {
       :cgi_path => '/xmlrpc.cgi',
-      :timeout => 120
+      :timeout  => 120
     }
 
     def xmlrpc_client


### PR DESCRIPTION
Also sets `use_ssl` and `port` based on URI scheme if they're not already set.

Tests still pass, but I haven't added any new ones.

Resolves #42

The default proxy host/port options don't need to be explicitly set anymore, since they default to nil in the options hash now.
