### PR TITLE
Add Rails support via a Railtie.

### DIFF
--- a/lib/active_bugzilla.rb
+++ b/lib/active_bugzilla.rb
@@ -8,6 +8,8 @@ require 'active_bugzilla/comment'
 require 'active_bugzilla/field'
 require 'active_bugzilla/flag'
 
+require 'active_bugzilla/railtie' if defined? ::Rails::Railtie
+
 module ActiveBugzilla
   # Convenience method for accessing ActiveBugzilla::Base.service.execute
   class << self

--- a/lib/active_bugzilla/base.rb
+++ b/lib/active_bugzilla/base.rb
@@ -1,5 +1,9 @@
 module ActiveBugzilla
   class Base
+    def self.connect!(*args)
+      @@service = ::ActiveBugzilla::Service.new(*args)
+    end
+
     def self.service=(service)
       @@service = service
     end

--- a/lib/active_bugzilla/railtie.rb
+++ b/lib/active_bugzilla/railtie.rb
@@ -1,0 +1,30 @@
+require 'rails'
+
+module ActiveBugzilla
+  class Railtie < ::Rails::Railtie
+    config.active_bugzilla = ActiveSupport::OrderedOptions.new
+
+    config.before_configuration do
+      config.active_bugzilla[:bugzilla_uri]      ||= ENV['BUGZILLA_URI']
+      config.active_bugzilla[:bugzilla_username] ||= ENV['BUGZILLA_USERNAME']
+      config.active_bugzilla[:bugzilla_password] ||= ENV['BUGZILLA_PASSWORD']
+    end
+
+    initializer 'active_bugzilla.configure' do |app|
+      uri      = app.config.active_bugzilla[:bugzilla_uri]
+      username = app.config.active_bugzilla[:bugzilla_username]
+      password = app.config.active_bugzilla[:bugzilla_password]
+
+      ::ActiveBugzilla::Base.connect!(uri, username, password)
+    end
+
+    rake_tasks do
+      namespace :bugzilla do
+        desc "Test your ActiveBugzilla base connection by getting the Bugzilla host version"
+        task :version => :environment do
+          puts ActiveBugzilla.execute('Bugzilla.version', {})['version']
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request includes the addition of a Railtie module, so ActiveBugzilla will be automatically initialized when added to a Rails project.

It can be configured in a Rails project in one of two ways:

1. Via ENV variables (default, if those variables are set)
2. Via the configure block in an environment file (standard for Rails plugins)

Also, when including ActiveBugzilla in a Rails project, a Rake task `bugzilla:version` will be made available to check the version of your Bugzilla host, just to make sure everything's working.