### PR TITLE
Keep all flag data

### DIFF
--- a/active_bugzilla.gemspec
+++ b/active_bugzilla.gemspec
@@ -8,7 +8,8 @@ Gem::Specification.new do |spec|
     "Joe VLcek"        => "jvlcek@redhat.com",
     "Jason Frey"       => "jfrey@redhat.com",
     "Oleg Barenboim"   => "chessbyte@gmail.com",
-    "Alberto Bellotti" => "abellott@redhat.com"
+    "Alberto Bellotti" => "abellott@redhat.com",
+    "Greg Blomquist"   => "gblomqui@redhat.com"
   }
 
   spec.name          = "active_bugzilla"

--- a/lib/active_bugzilla/bug/flags_management.rb
+++ b/lib/active_bugzilla/bug/flags_management.rb
@@ -7,10 +7,7 @@ module ActiveBugzilla::Bug::FlagsManagement
   module ClassMethods
     def flags_from_raw_flags_data(raw_flags_data)
       return {} if raw_flags_data.nil?
-      flag_objects = ActiveBugzilla::Flag.instantiate_from_raw_data(raw_flags_data)
-      flag_objects.each_with_object({}) do |flag, hash|
-        hash[flag.name] = flag.status
-      end
+      ActiveBugzilla::Flag.instantiate_from_raw_data(raw_flags_data).collect(&:attributes)
     end
   end
 

--- a/lib/active_bugzilla/flag.rb
+++ b/lib/active_bugzilla/flag.rb
@@ -1,6 +1,6 @@
 module ActiveBugzilla
   class Flag < Base
-    attr_reader :active, :bug_id, :created_on, :id, :name, :setter, :status, :type_id, :updated_on
+    attr_reader :active, :bug_id, :created_on, :id, :name, :setter, :requestee, :status, :type_id, :updated_on
     alias_method :active?, :active
 
     def initialize(attributes)
@@ -13,6 +13,7 @@ module ActiveBugzilla
       @name       = attributes['name']
       @setter     = attributes['setter']
       @active     = attributes['is_active']
+      @requestee  = attributes['requestee']
     end
 
     def self.instantiate_from_raw_data(data, bug_id = nil)

--- a/lib/active_bugzilla/flag.rb
+++ b/lib/active_bugzilla/flag.rb
@@ -4,16 +4,24 @@ module ActiveBugzilla
     alias_method :active?, :active
 
     def initialize(attributes)
-      @id         = attributes['id']
-      @bug_id     = attributes['bug_id']
-      @type_id    = attributes['type_id']
-      @created_on = normalize_timestamp(attributes['creation_date'])
-      @updated_on = normalize_timestamp(attributes['modification_date'])
-      @status     = attributes['status']
-      @name       = attributes['name']
-      @setter     = attributes['setter']
-      @active     = attributes['is_active']
-      @requestee  = attributes['requestee']
+      @attributes = attributes.dup
+      @attributes['created_on'] = normalize_timestamp(@attributes.delete('creation_date'))
+      @attributes['updated_on'] = normalize_timestamp(@attributes.delete('modification_date'))
+
+      @id         = @attributes['id']
+      @bug_id     = @attributes['bug_id']
+      @type_id    = @attributes['type_id']
+      @created_on = @attributes['created_on']
+      @updated_on = @attributes['updated_on']
+      @status     = @attributes['status']
+      @name       = @attributes['name']
+      @setter     = @attributes['setter']
+      @active     = @attributes['is_active']
+      @requestee  = @attributes['requestee']
+    end
+
+    def attributes
+      @attributes
     end
 
     def self.instantiate_from_raw_data(data, bug_id = nil)

--- a/lib/active_bugzilla/version.rb
+++ b/lib/active_bugzilla/version.rb
@@ -1,3 +1,3 @@
 module ActiveBugzilla
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
This PR does two things:

1)  Adds the "requestee" field to the flag object

2)  Updates the format of the returned flags so that all of the flag data is returned to the caller.

As a library, the ActiveBugzilla gem should not assume that all callers only want a subset of flag data.

Now, the ActiveBugzilla gem will return all of the available flag data as an array of hashes.

Previously a bug's flags would appear as:
```ruby
  flags = {"devel_ack" => "?", "qa_ack" => "?"}
```

Now, a bug's flags will appear as:
```ruby
  flags = [{"is_active"  => 1, 
            "status"     => "?", 
            "type_id"    => 10, 
            "name"       => "devel_ack",
            "id"         => 11111, 
            "setter"     => "setter@email.com", 
            "bug_id"     => nil,
            "created_on" => 2015-04-10 11:11:11 UTC,
            "updated_on" => 2015-04-10 11:11:11 UTC },
           {"requestee"  => "requestee@email.com",
            "is_active"  => 1, 
            "status"     => "?", 
            "type_id"    => 10, 
            "name"       => "needinfo",
            "id"         => 22222, 
            "setter"     => "setter@email.com", 
            "bug_id"     => nil,
            "created_on" => 2015-04-10 10:00:00 UTC,
            "updated_on" => 2015-04-10 10:00:00 UTC }]
```

This will allow different clients to choose how much flag data is important.

NOTE: This breaks the API for any client relying on the previous format of the flags.