### PR TITLE
Update specs to remove deprecation and other warnings

### DIFF
--- a/spec/active_bugzilla/bug_spec.rb
+++ b/spec/active_bugzilla/bug_spec.rb
@@ -10,8 +10,8 @@ describe ActiveBugzilla::Bug do
       }
       @service = double('service')
       ActiveBugzilla::Base.service = @service
-      described_class.stub(:generate_xmlrpc_map).and_return(@service_mapping)
-      described_class.stub(:xmlrpc_timestamps).and_return([])
+      allow(described_class).to receive(:generate_xmlrpc_map).and_return(@service_mapping)
+      allow(described_class).to receive(:xmlrpc_timestamps).and_return([])
       @id  = 123
       @bug = described_class.new(:id => @id)
     end
@@ -20,21 +20,20 @@ describe ActiveBugzilla::Bug do
       raw_keys = @service_mapping.values
       raw_data = {}
       raw_keys.each { |k| raw_data[k.to_s] = 'foo' }
-      @bug.stub(:raw_data).and_return(raw_data)
       expect(@bug.attribute_names).to eq(@service_mapping.keys.sort_by { |key| key.to_s })
     end
 
     it "severity" do
       severity = 'foo'
       raw_data = {'severity_xmlrpc' => severity}
-      @bug.stub(:raw_data).and_return(raw_data)
+      expect(@bug).to receive(:raw_data).and_return(raw_data)
       expect(@bug.severity).to eq(severity)
     end
 
     it "comments" do
       comments_hash = [{'id' => 1}]
       raw_data = {'comments' => comments_hash}
-      @bug.stub(:raw_data).and_return(raw_data)
+      expect(@bug).to receive(:raw_data).and_return(raw_data)
       comments = @bug.comments
       expect(comments).to be_kind_of(Array)
       expect(comments.count).to eq(1)

--- a/spec/active_bugzilla/service_spec.rb
+++ b/spec/active_bugzilla/service_spec.rb
@@ -114,7 +114,7 @@ describe ActiveBugzilla::Service do
         ]
       }
 
-      described_class.any_instance.stub(:get).and_return([existing_bz])
+      expect(bz).to receive(:get).and_return([existing_bz])
       allow(::XMLRPC::Client).to receive(:new)
         .and_return(double('xmlrpc_create', :call => output, :set_parser => nil))
       new_bz_id = bz.clone("948972")
@@ -159,7 +159,7 @@ describe ActiveBugzilla::Service do
         ]
       }
 
-      described_class.any_instance.stub(:get).and_return([existing_bz])
+      expect(bz).to receive(:get).and_return([existing_bz])
       allow(::XMLRPC::Client).to receive(:new)
         .and_return(double('xmlrpc_create', :call => output, :set_parser => nil))
       new_bz_id = bz.clone("948972", "assigned_to" => "Ham@NASA.gov", "target_release" => ["2.2.0"])

--- a/spec/active_bugzilla/service_spec.rb
+++ b/spec/active_bugzilla/service_spec.rb
@@ -75,8 +75,8 @@ describe ActiveBugzilla::Service do
     it "when the specified bug to clone does not exist" do
       output = {}
 
-      allow(::XMLRPC::Client).to receive(:new).and_return(double('xmlrpc_client', :call => output))
-      expect { bz.clone(94897099) }.to raise_error
+      allow(::XMLRPC::Client).to receive(:new).and_return(double('xmlrpc_client', :call => output, :set_parser => nil))
+      expect { bz.clone(94897099) }.to raise_error NoMethodError
     end
 
     it "when producing valid output" do

--- a/spec/active_bugzilla_spec.rb
+++ b/spec/active_bugzilla_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe ActiveBugzilla do
   it "::VERSION" do
-    described_class::VERSION.should be_kind_of(String)
+    expect(described_class::VERSION).to be_kind_of(String)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
 
   # Run specs in random order to surface order dependencies. If you find an


### PR DESCRIPTION
Changes
-------

- Updates `spec_helper.rb` to remove an unecessary config
- Fixes uses of `.should`
- Fixes uses of `.stub`
- Fixes uses of `.raise_error` without passing an error class