### PR TITLE
Create custom error class for "Not Found" BZs

### DIFF
--- a/lib/active_bugzilla/bug.rb
+++ b/lib/active_bugzilla/bug.rb
@@ -2,6 +2,16 @@ require 'active_model'
 
 module ActiveBugzilla
   class Bug < Base
+
+    # Error class for when a BZ can't be found
+    class NotFound < StandardError
+      def initialize(id=nil)
+        msg = nil
+        msg = "no BZ with id #{id} found!" if id
+        super(msg)
+      end
+    end
+
     include ActiveModel::Validations
     include ActiveModel::Dirty
 

--- a/lib/active_bugzilla/service.rb
+++ b/lib/active_bugzilla/service.rb
@@ -153,6 +153,8 @@ module ActiveBugzilla
 
       existing_bz = get(bug_id, :include_fields => CLONE_FIELDS).first
 
+      raise ActiveBugzilla::Bug::NotFound.new(bug_id) if existing_bz.nil?
+
       clone_description, clone_comment_is_private = assemble_clone_description(existing_bz)
 
       params = {}

--- a/spec/active_bugzilla/bug_spec.rb
+++ b/spec/active_bugzilla/bug_spec.rb
@@ -10,8 +10,8 @@ describe ActiveBugzilla::Bug do
       }
       @service = double('service')
       ActiveBugzilla::Base.service = @service
-      described_class.stub(:generate_xmlrpc_map).and_return(@service_mapping)
-      described_class.stub(:xmlrpc_timestamps).and_return([])
+      allow(described_class).to receive(:generate_xmlrpc_map).and_return(@service_mapping)
+      allow(described_class).to receive(:xmlrpc_timestamps).and_return([])
       @id  = 123
       @bug = described_class.new(:id => @id)
     end
@@ -20,21 +20,20 @@ describe ActiveBugzilla::Bug do
       raw_keys = @service_mapping.values
       raw_data = {}
       raw_keys.each { |k| raw_data[k.to_s] = 'foo' }
-      @bug.stub(:raw_data).and_return(raw_data)
       expect(@bug.attribute_names).to eq(@service_mapping.keys.sort_by { |key| key.to_s })
     end
 
     it "severity" do
       severity = 'foo'
       raw_data = {'severity_xmlrpc' => severity}
-      @bug.stub(:raw_data).and_return(raw_data)
+      expect(@bug).to receive(:raw_data).and_return(raw_data)
       expect(@bug.severity).to eq(severity)
     end
 
     it "comments" do
       comments_hash = [{'id' => 1}]
       raw_data = {'comments' => comments_hash}
-      @bug.stub(:raw_data).and_return(raw_data)
+      expect(@bug).to receive(:raw_data).and_return(raw_data)
       comments = @bug.comments
       expect(comments).to be_kind_of(Array)
       expect(comments.count).to eq(1)

--- a/spec/active_bugzilla/service_spec.rb
+++ b/spec/active_bugzilla/service_spec.rb
@@ -114,7 +114,7 @@ describe ActiveBugzilla::Service do
         ]
       }
 
-      described_class.any_instance.stub(:get).and_return([existing_bz])
+      expect(bz).to receive(:get).and_return([existing_bz])
       allow(::XMLRPC::Client).to receive(:new)
         .and_return(double('xmlrpc_create', :call => output, :set_parser => nil))
       new_bz_id = bz.clone("948972")
@@ -159,7 +159,7 @@ describe ActiveBugzilla::Service do
         ]
       }
 
-      described_class.any_instance.stub(:get).and_return([existing_bz])
+      expect(bz).to receive(:get).and_return([existing_bz])
       allow(::XMLRPC::Client).to receive(:new)
         .and_return(double('xmlrpc_create', :call => output, :set_parser => nil))
       new_bz_id = bz.clone("948972", "assigned_to" => "Ham@NASA.gov", "target_release" => ["2.2.0"])

--- a/spec/active_bugzilla/service_spec.rb
+++ b/spec/active_bugzilla/service_spec.rb
@@ -73,10 +73,11 @@ describe ActiveBugzilla::Service do
     end
 
     it "when the specified bug to clone does not exist" do
-      output = {}
+      output        = {}
+      error_message = "no BZ with id 94897099 found!"
 
       allow(::XMLRPC::Client).to receive(:new).and_return(double('xmlrpc_client', :call => output, :set_parser => nil))
-      expect { bz.clone(94897099) }.to raise_error NoMethodError
+      expect { bz.clone(94897099) }.to raise_error ActiveBugzilla::Bug::NotFound, error_message
     end
 
     it "when producing valid output" do

--- a/spec/active_bugzilla/service_spec.rb
+++ b/spec/active_bugzilla/service_spec.rb
@@ -75,8 +75,8 @@ describe ActiveBugzilla::Service do
     it "when the specified bug to clone does not exist" do
       output = {}
 
-      allow(::XMLRPC::Client).to receive(:new).and_return(double('xmlrpc_client', :call => output))
-      expect { bz.clone(94897099) }.to raise_error
+      allow(::XMLRPC::Client).to receive(:new).and_return(double('xmlrpc_client', :call => output, :set_parser => nil))
+      expect { bz.clone(94897099) }.to raise_error NoMethodError
     end
 
     it "when producing valid output" do

--- a/spec/active_bugzilla_spec.rb
+++ b/spec/active_bugzilla_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe ActiveBugzilla do
   it "::VERSION" do
-    described_class::VERSION.should be_kind_of(String)
+    expect(described_class::VERSION).to be_kind_of(String)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
 
   # Run specs in random order to surface order dependencies. If you find an


### PR DESCRIPTION
Built off of #50 and so a better diff for this change can be found here (until that is merged):

https://github.com/NickLaMuro/active_bugzilla/compare/all_the_rspec_fixes...better_error_for_not_found

Previously, when a BZ was attempted to be cloned, and the origin BZ was not found, the code continues on as if one was found until it receives a `NoMethodError` because the code tries calling `[]` on `nil`.

This catches that scenario and raises a much more user friendly error, and updates the specs to reflect the change.

* * *

Put this in a separate PR since the base PR fixes the error as the code is currently, but this requires a "feature change" (sort of) to work.