### PR TITLE
Exercise XMLRPC::Client in specs

### DIFF
--- a/lib/active_bugzilla/service.rb
+++ b/lib/active_bugzilla/service.rb
@@ -160,7 +160,9 @@ module ActiveBugzilla
       params = {}
       CLONE_FIELDS.each do |field|
         next if field == :comments
-        params[field] = existing_bz[field.to_s]
+        existing_val = existing_bz[field.to_s]
+        next if existing_val.nil?
+        params[field] = existing_val
       end
 
       # Apply overrides

--- a/lib/active_bugzilla/service.rb
+++ b/lib/active_bugzilla/service.rb
@@ -226,7 +226,7 @@ module ActiveBugzilla
     end
 
     def assemble_clone_description(existing_bz)
-      clone_description = " +++ This bug was initially created as a clone of Bug ##{existing_bz[:id]} +++ \n"
+      clone_description = " +++ This bug was initially created as a clone of Bug ##{existing_bz[:id.to_s]} +++ \n"
       clone_description << existing_bz[:description.to_s]
 
       clone_comment_is_private = false

--- a/lib/active_bugzilla/testing/fake_bugzilla_server.rb
+++ b/lib/active_bugzilla/testing/fake_bugzilla_server.rb
@@ -1,0 +1,239 @@
+require "socket"
+require "xmlrpc/server"
+require "webrick" # preload here so it isn't slow in spec
+require "active_support/core_ext/array/extract_options"
+
+# A singleton server to be used in testing.  Provides a DSL for defining stub
+# actions/responses, along with param validation.
+#
+# See FakeBugzillaServer::start_with for more info on defining a server.
+class FakeBugzillaServer
+  DEFAULT_HOST = "127.0.0.1".freeze
+
+  # Start a server, and define proper actions via a block.
+  #
+  #   FakeBugzillaServer.start_with do
+  #     action("one") { { "body" => "1" } }
+  #     action("two") { { "body" => "2" } }
+  #   end
+  #
+  # The actions are instance_eval'd, so to properly pass variables defined
+  # outside of the block, the options hash of this method will define those and
+  # make them available inside the actions.
+  #
+  #   method_response_1 = { "body" => "1" }
+  #   FakeBugzillaServer.start_with :method_response_1 => method_response_1 do
+  #     action("one") { method_response_1 }
+  #     action("two") { { "body" => "2" } }
+  #   end
+  #
+  # See FakeBugzillaServer.action for more info for defining individual
+  # actions.
+  def self.start_with(*server_args, &block)
+    @local_vars = server_args.extract_options!
+    setup_server(*server_args)
+    instance_eval(&block) if block_given?
+    @bugzilla.serve
+  end
+
+  def self.stop
+    return unless @bugzilla
+    @bugzilla.shutdown
+    @bugzilla, @server_port = nil
+  end
+
+  # Defines a handler for the server, using a FakeBugzillaServerResponse
+  # instance for the response block.
+  #
+  # See FakeBugzillaServerResponse for more info the the action DSL
+  def self.action(action_key, &response_block)
+    responder = FakeBugzillaServerResponse.new(@local_vars, &response_block).responder
+    @bugzilla.add_handler(action_key, &responder)
+  end
+
+  # Defines the server (@bugzilla) instance variable.
+  #
+  # See XMLRPC::ThreadServer below for more info on the specific server class
+  # implementation
+  def self.setup_server(host = nil, port = nil)
+    @server_host = host || server_host
+    @server_port = port || server_port
+    @bugzilla    = XMLRPC::ThreadServer.new(server_port, server_host, 1, File::NULL)
+  end
+
+  def self.server_port
+    @server_port ||= TCPServer.open(server_host, 0) { |sock| sock.addr[1] }
+    @server_port
+  end
+
+  def self.server_host
+    @server_host ||= DEFAULT_HOST
+  end
+end
+
+# Based off the Hub::LocalServer helper class
+#
+#   https://github.com/github/hub/blob/abda01df/features/support/local_server.rb#L64
+#
+# This is a helper class for defining actions on the FakeBugzillaServer, which
+# allows for a DSL for validating mock actions.  This allows validating the
+# params passed match specific values, or are not included at all, in to ensure
+# other portions of the client code is working correctly.
+#
+# Example:
+#
+#   FakeBugzillaServer.start_with do
+#     action "Foo.foo" do
+#       assert_bugzilla_auth "username", "password"
+#       assert_parms "foo" => "foo"
+#                    "bar" => :no
+#
+#       # response
+#       { "foo" => "foo" }
+#     end
+#
+#     action "Foo.bar" do
+#       halt "Only 'foo' actions are acceptable here..."
+#     end
+#   end
+class FakeBugzillaServerResponse
+  attr_reader :params
+
+  def initialize(local_vars, &response_block)
+    @response_block = response_block
+
+    # Allow passing variables and treat them as instance methods
+    local_vars.each do |method, val|
+      define_singleton_method(method) { val }
+    end
+  end
+
+  # :nodoc:
+  #
+  # Builds the Proc that is used by FakeBugzillaServer to define a
+  # `add_handler` method.
+  #
+  # Sets the `@params` that would be passed into the `add_handler` to the
+  # instance variable, so it can easily be accessed by the DSL methods without
+  # needing to pass it around as method args..
+  def responder
+    proc do |params|
+      @params = params
+      instance_eval(&@response_block)
+    end
+  end
+
+  # Checks the values of individual params.  Works in two modes:
+  #
+  # Equivalency check (checks the param is equal):
+  #
+  #   assert_params "foo" => "foo"
+  #
+  #
+  # Non-existence check (checks the param do not exist):
+  #
+  #   assert_params "foo" => :no
+  #
+  #
+  # Both modes can be mixed and matched in a single call
+  #
+  #   assert_params "foo" => "foo"
+  #                 "bar" => :no
+  #
+  #
+  # Invalid requests will be raised if these values do not match as expected,
+  # causing an error on the client.
+  def assert_params(expected)
+    expected.each do |key, value|
+      if value && params.key?(key.to_s) == :no
+        error_vals = {
+          :key   => key.inspect,
+          :value => params[key].inspect
+        }
+        error_msg = "expected %{key} not to be passed; got %{value}"
+        halt(error_msg % error_vals)
+      elsif params[key] != value
+        error_vals = {
+          :key      => key.inspect,
+          :expected => value.inspect,
+          :actual   => params[key].inspect
+        }
+        error_msg = "expected %{key} to be %{expected}; got %{actual}"
+        halt(error_msg % error_vals)
+      end
+    end
+  end
+
+  # Checks the value of "Bugzilla_login" and "Bugzilla_password" are the
+  # correct `username` and `password` values respectively.  An error is thrown
+  # if either of the params don't match.
+  def assert_bugzilla_auth(username, password)
+    if params["Bugzilla_login"] != username
+      error_vals = {
+        :expected => username.inspect,
+        :actual   => params["Bugzilla_login"].inspect
+      }
+      error_msg = "expected login to be %{expected}, but was %{actual}"
+      halt(error_msg % error_vals)
+    elsif params["Bugzilla_password"] != password
+      error_vals = {
+        :expected => password.inspect,
+        :actual   => params["Bugzilla_password"].inspect
+      }
+      error_msg = "expected to be password to be %{expected}, but was %{actual}"
+      halt(error_msg % error_vals)
+    end
+  end
+
+  # Raise an error with the given message that the XMLRPC client will process
+  # properly.
+  def halt(msg)
+    raise XMLRPC::FaultException.new(1, msg)
+  end
+end
+
+# Wrapper class around XMLRPC::Server to run it in a thread
+#
+#   xmlrpc_server = XMLRPC::ThreadServer.new "127.0.0.1", 12345
+#   xmlrpc_server.add_handler("foo") { "foo" }
+#   xmlrpc_server.start
+#
+#   some_xmlrpc_client.call("foo")
+#   # => "foo"
+#
+#   xmlrpc_server.stop
+#
+# The `XMLRPC::Server` uses a `WEBrick::HTTPServer` to handle it's requests,
+# but it is indended to be the only thing run in the process.
+#
+# This class overwrites the `serve` and `shutdown methods in that class to run
+# them in a Thread, but also remove the logging.  The `@config[:AccessLog]` is
+# updated in the `serve` method just so we can retain the entire `initialize`
+# method from `XMLRPC::Server` class.
+#
+module XMLRPC
+  class ThreadServer < Server
+    def serve
+      @server.config[:AccessLog] = []
+      @server_thread = Thread.new { @server.start }
+
+      # HACK:  There is a race condition with starting WEBrick and shutting
+      # it down in rapid succession, causing a deadlock.  This was fixed the
+      # properly in Ruby 2.5:
+      #
+      #   https://bugs.ruby-lang.org/issues/4841
+      #   https://github.com/ruby/ruby/commit/22474d8f
+      #
+      # But since we can't rely on this being there for many versions of ruby,
+      # and doing this the right way with some kind of Mutex/ConditionVariable
+      # would require a lot more monkey patching, so the `until` approach is
+      # the easiest way to handle a work around
+      sleep 0.001 until @server.status == :Running
+    end
+
+    def shutdown
+      @server.shutdown
+      @server_thread.join
+    end
+  end
+end

--- a/spec/active_bugzilla/service_spec.rb
+++ b/spec/active_bugzilla/service_spec.rb
@@ -1,7 +1,10 @@
+# rubocop:disable Style/NumericLiterals
 require 'spec_helper'
 
-describe ActiveBugzilla::Service do
-  let(:bz) { described_class.new("http://uri.to/bugzilla", "calvin", "hobbes") }
+describe ActiveBugzilla::Service, :include_bugzilla_server_helper do
+  let(:host) { "http://#{FakeBugzillaServer.server_host}" }
+  let(:port) { FakeBugzillaServer.server_port }
+  let(:bz)   { described_class.new(host, "calvin", "hobbes", :port => port) }
 
   context "#new" do
     it 'normal case' do
@@ -31,29 +34,41 @@ describe ActiveBugzilla::Service do
     end
 
     it "when the specified bug does not exist" do
-      output = {}
-
-      allow(::XMLRPC::Client).to receive(:new)
-        .and_return(double('xmlrpc_client', :call => output, :set_parser => nil))
+      with_a_bz_server_definition do
+        action("Bug.get") do
+          assert_bugzilla_auth "calvin", "hobbes"
+          assert_params        "ids" => [94897099]
+          {}
+        end
+      end
       matches = bz.get(94897099)
+      stop_bz_server
+
       expect(matches).to be_kind_of(Array)
       expect(matches).to be_empty
     end
 
     it "when producing valid output" do
-      output = {
-        'bugs' => [
-          {
-            "priority" => "unspecified",
-            "keywords" => ["ZStream"],
-            "cc"       => ["calvin@redhat.com", "hobbes@RedHat.com"],
-          },
-        ]
-      }
+      with_a_bz_server_definition do
+        action "Bug.get" do
+          assert_bugzilla_auth "calvin", "hobbes"
+          assert_params        "ids" => ["948972"]
 
-      allow(::XMLRPC::Client).to receive(:new)
-        .and_return(double('xmlrpc_client', :call => output, :set_parser => nil))
+          {
+            'bugs' => [
+              {
+                "priority" => "unspecified",
+                "keywords" => ["ZStream"],
+                "cc"       => ["calvin@redhat.com", "hobbes@RedHat.com"],
+              },
+            ]
+          }
+        end
+      end
+
       existing_bz = bz.get("948972").first
+
+      stop_bz_server
 
       expect(bz.last_command).to include("Bug.get")
 
@@ -64,6 +79,135 @@ describe ActiveBugzilla::Service do
   end
 
   context "#clone" do
+    let(:commenter_1)      { "Calvin@redhat.com" }
+    let(:commenter_2)      { "Hobbes@redhat.com" }
+    let(:overwrite_params) { {} }
+    let(:existing_bz) do
+      {
+        "id"             => 948972,
+        "description"    => "Description of problem:\n\nIt's Broken",
+        "priority"       => "unspecified",
+        "assigned_to"    => "calvin@redhat.com",
+        "target_release" => ["---"],
+        "keywords"       => ["ZStream"],
+        "cc"             => ["calvin@redhat.com", "hobbes@RedHat.com"],
+        "comments"       => [
+          {
+            "is_private"    => false,
+            "count"         => 0,
+            "time"          => XMLRPC::DateTime.new(1969, 7, 20, 16, 18, 30),
+            "bug_id"        => 948970,
+            "author"        => commenter_1,
+            "text"          => "It's Broken and impossible to reproduce",
+            "creation_time" => XMLRPC::DateTime.new(1969, 7, 20, 16, 18, 30),
+            "id"            => 5777871,
+            "creator_id"    => 349490
+          },
+          {
+            "is_private"    => false,
+            "count"         => 1,
+            "time"          => XMLRPC::DateTime.new(1970, 11, 10, 16, 18, 30),
+            "bug_id"        => 948970,
+            "author"        => commenter_2,
+            "text"          => "Fix Me Now!",
+            "creation_time" => XMLRPC::DateTime.new(1972, 2, 14, 0, 0, 0),
+            "id"            => 5782170,
+            "creator_id"    => 349490
+          },
+        ]
+      }
+    end
+
+    # Note:  For the first comment's `:creation_time`, this ends up being `nil`
+    # on older versions of ruby do to the fact that the `to_time` method used to
+    # call out to `Time.gm(XMLRPC::DateTime#to_a)`, and in pre Ruby 2.0, this
+    # would return `nil` if the year was less than 1970 (epoch):
+    #
+    #   https://github.com/ruby/ruby/blob/23ccbdf5/lib/xmlrpc/datetime.rb#L113-L119
+    #
+    # This has since changed:
+    #
+    #   https://github.com/ruby/xmlrpc/commit/7a7a3afc
+    #
+    # But for ruby version compatibility, this is calculated again here so it can
+    # be conditionally defined based on Ruby version.
+    let(:comment_1_time) do
+      existing_bz["comments"].first["creation_time"].to_time # rubocop:disable Rails/Date
+    end
+
+    # rubocop:disable Layout/TrailingWhitespace
+    #
+    # required disable since the string in the model has a space at the end of
+    # the first line
+    let(:clone_description) do
+      <<-BZ_DESCRIPTION.gsub(/^ {8}/, '').chomp
+         +++ This bug was initially created as a clone of Bug ##{existing_bz["id"]} +++ 
+        Description of problem:
+
+        It's Broken
+
+        **********************************************************************
+        Following comment by #{commenter_1} on #{comment_1_time}
+
+
+
+        It's Broken and impossible to reproduce
+
+        **********************************************************************
+        Following comment by #{commenter_2} on 1972-02-14 00:00:00 UTC
+
+
+
+        Fix Me Now!
+      BZ_DESCRIPTION
+    end
+    # rubocop:enable Layout/TrailingWhitespace
+
+    before do
+      fake_bz_server_vars = {
+        :existing_bz       => existing_bz,
+        :overwrite_params  => overwrite_params,
+        :clone_description => clone_description
+      }
+      with_a_bz_server_definition fake_bz_server_vars do
+        action "Bug.get" do
+          if params["ids"] == [94897099]
+            # non-existant BZ
+            #
+            # FIXME:  We probably should re-write this spec, since bugzilla's
+            # xmlrpc seems to throw an error when the BZ doesn't exist, and not
+            # just an empty XML struct.
+            {}
+          else
+            extra_fields = ActiveBugzilla::Service::CLONE_FIELDS.map(&:to_s)
+
+            assert_bugzilla_auth "calvin", "hobbes"
+            assert_params        "ids"            => [948972],
+                                 "include_fields" => extra_fields
+
+            { "bugs" => [existing_bz] }
+          end
+        end
+
+        action "Bug.create" do
+          expected_params = existing_bz.merge({
+            "cf_clone_of"        => existing_bz["id"],
+            "description"        => clone_description,
+            "comment_is_private" => false
+          }.merge(overwrite_params))
+          expected_params.delete("comments")
+          expected_params.delete("id")
+
+          assert_bugzilla_auth "calvin", "hobbes"
+          assert_params        expected_params
+
+          { "id" => 948992 }
+        end
+      end
+    end
+
+    after { stop_bz_server }
+
     it "when no argument is specified" do
       expect { bz.clone }.to raise_error(ArgumentError)
     end
@@ -73,102 +217,38 @@ describe ActiveBugzilla::Service do
     end
 
     it "when the specified bug to clone does not exist" do
-      output        = {}
-      error_message = "no BZ with id 94897099 found!"
-
-      allow(::XMLRPC::Client).to receive(:new).and_return(double('xmlrpc_client', :call => output, :set_parser => nil))
-      expect { bz.clone(94897099) }.to raise_error ActiveBugzilla::Bug::NotFound, error_message
+      expect { bz.clone(94897099) }.to raise_error ActiveBugzilla::Bug::NotFound
     end
 
-    it "when producing valid output" do
-      output = {"id" => 948992}
-      existing_bz = {
-        "description"    => "Description of problem:\n\nIt's Broken",
-        "priority"       => "unspecified",
-        "assigned_to"    => "calvin@redhat.com",
-        "target_release" => ["---"],
-        "keywords"       => ["ZStream"],
-        "cc"             => ["calvin@redhat.com", "hobbes@RedHat.com"],
-        "comments"       => [
-          {
-            "is_private"    => false,
-            "count"         => 0,
-            "time"          => XMLRPC::DateTime.new(1969, 7, 20, 16, 18, 30),
-            "bug_id"        => 948970,
-            "author"        => "Calvin@redhat.com",
-            "text"          => "It's Broken and impossible to reproduce",
-            "creation_time" => XMLRPC::DateTime.new(1969, 7, 20, 16, 18, 30),
-            "id"            => 5777871,
-            "creator_id"    => 349490
-          },
-          {
-            "is_private"    => false,
-            "count"         => 1,
-            "time"          => XMLRPC::DateTime.new(1970, 11, 10, 16, 18, 30),
-            "bug_id"        => 948970,
-            "author"        => "Hobbes@redhat.com",
-            "text"          => "Fix Me Now!",
-            "creation_time" => XMLRPC::DateTime.new(1972, 2, 14, 0, 0, 0),
-            "id"            => 5782170,
-            "creator_id"    => 349490
-          },
-        ]
-      }
+    context "when producing valid output" do
+      it "creates the new BZ and returns the new BZ ID" do
+        new_bz_id = bz.clone(existing_bz["id"])
+        expect(bz.last_command).to include("Bug.create")
 
-      expect(bz).to receive(:get).and_return([existing_bz])
-      allow(::XMLRPC::Client).to receive(:new)
-        .and_return(double('xmlrpc_create', :call => output, :set_parser => nil))
-      new_bz_id = bz.clone("948972")
-
-      expect(bz.last_command).to include("Bug.create")
-
-      expect(new_bz_id).to eq(output["id"])
+        expect(new_bz_id).to eq(948992)
+      end
     end
 
-    it "when providing override values" do
-      output = {"id" => 948992}
-      existing_bz = {
-        "description"    => "Description of problem:\n\nIt's Broken",
-        "priority"       => "unspecified",
-        "assigned_to"    => "calvin@redhat.com",
-        "target_release" => ["---"],
-        "keywords"       => ["ZStream"],
-        "cc"             => ["calvin@redhat.com", "hobbes@RedHat.com"],
-        "comments"       => [
-          {
-            "is_private"    => false,
-            "count"         => 0,
-            "time"          => XMLRPC::DateTime.new(1969, 7, 20, 16, 18, 30),
-            "bug_id"        => 948970,
-            "author"        => "Buzz.Aldrin@redhat.com",
-            "text"          => "It's Broken and impossible to reproduce",
-            "creation_time" => XMLRPC::DateTime.new(1969, 7, 20, 16, 18, 30),
-            "id"            => 5777871,
-            "creator_id"    => 349490
-          },
-          {
-            "is_private"    => false,
-            "count"         => 1,
-            "time"          => XMLRPC::DateTime.new(1970, 11, 10, 16, 18, 30),
-            "bug_id"        => 948970,
-            "author"        => "Neil.Armstrong@redhat.com",
-            "text"          => "Fix Me Now!",
-            "creation_time" => XMLRPC::DateTime.new(1972, 2, 14, 0, 0, 0),
-            "id"            => 5782170,
-            "creator_id"    => 349490
-          },
-        ]
-      }
+    context "when providing override values" do
+      let(:commenter_1) { "Buzz.Aldrin@redhat.com" }
+      let(:commenter_2) { "Neil.Armstrong@redhat.com" }
 
-      expect(bz).to receive(:get).and_return([existing_bz])
-      allow(::XMLRPC::Client).to receive(:new)
-        .and_return(double('xmlrpc_create', :call => output, :set_parser => nil))
-      new_bz_id = bz.clone("948972", "assigned_to" => "Ham@NASA.gov", "target_release" => ["2.2.0"])
+      let(:overwrite_params) do
+        {
+          "assigned_to"    => "Ham@NASA.gov",
+          "target_release" => ["2.2.0"]
+        }
+      end
 
-      expect(bz.last_command).to include("Bug.create")
+      it "creates the new BZ with the updated params and returns the new ID" do
+        new_bz_id = bz.clone(948972, overwrite_params)
 
-      expect(new_bz_id).to eq(output["id"])
+        expect(bz.last_command).to include("Bug.create")
+
+        expect(new_bz_id).to eq(948992)
+      end
     end
   end
 
 end
+# rubocop:enable Style/NumericLiterals

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,11 @@
 # loaded once.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+# Requires supporting files with custom matchers and macros, etc,
+# in ./support/ and its subdirectories.
+Dir[File.expand_path(File.join(__FILE__, '../support/**/*.rb'))].each { |f| require f }
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 

--- a/spec/support/fake_bugzilla_helper.rb
+++ b/spec/support/fake_bugzilla_helper.rb
@@ -1,0 +1,11 @@
+require "active_bugzilla/testing/fake_bugzilla_server"
+
+shared_context "bugzilla server helper methods", :include_bugzilla_server_helper do
+  def with_a_bz_server_definition(*options, &block)
+    FakeBugzillaServer.start_with(*options, &block)
+  end
+
+  def stop_bz_server
+    FakeBugzillaServer.stop
+  end
+end


### PR DESCRIPTION
Built of off #50 ([WIP] until that is merged)

At a high level, this PR does two things:

- Adds a library class called `FakeBugzillaServer`, which is in charge of creating a `XMLRPC::Server` in a separate thread that is configurable with custom responses
- Updates specs to remove stubbing and point to a `FakeBugzillaServer` endpoint instead.

There is a lot that was done as part of this to get this working, along with a few bug fixes that were necessary as well.  I have attempted to document this as best as can, as well as provided explanations for each of the commits, so I encourage reading those for more info.  This is mostly a pre-req for updating the XMLRPC parsing lib to something that works on new versions of Ruby (2.3+), while allowing us to be confident that the changes to that would be somewhat exercised.


cc @Fryguy @jrafanie