### PR TITLE
Add configs for rubocop/yamllint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from:
+- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+# put all local rubocop config into .rubocop_local.yml as it will be loaded by .rubocop_cc.yml as well
+- .rubocop_local.yml

--- a/.rubocop_cc.yml
+++ b/.rubocop_cc.yml
@@ -1,0 +1,5 @@
+inherit_from:
+# this is downloaded by .codeclimate.yml
+- .rubocop_base.yml
+- .rubocop_cc_base.yml
+- .rubocop_local.yml

--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,0 +1,2 @@
+# GlobalVars:
+#   AllowedVariables:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,13 @@
+---
+ignore: |
+  /vendor/**
+  /spec/manageiq/**
+  /spec/vcr_cassettes/**
+
+extends: relaxed
+
+rules:
+  indentation:
+    indent-sequences: false
+  line-length:
+    max: 120


### PR DESCRIPTION
Title says it all.

If all works correctly, this PR should hopefully have a passing message from `@miq_bot`, and not something along the lines of:

> Checked commits NickLaMuro/active_bugzilla@dd8d6d7~...8d3b30f with ruby 2.3.3, rubocop 0.52.1, haml-lint 0.20.0, and yamllint 1.10.0
> 8 files checked, 2 offenses detected
> 
> **
> 
> 💣 💥 🔥 🚒 - Linter/Rubocop - missing config files
> 💣 💥 🔥 🚒 - Linter/Yaml - missing config files